### PR TITLE
Dynamic output depending on the running OS

### DIFF
--- a/src/Ping.php
+++ b/src/Ping.php
@@ -135,7 +135,7 @@ class Ping
 
     protected function addPacketCountOption(): self
     {
-        $this->currentCommand[] = '-c';
+        $this->currentCommand[] = PHP_OS_FAMILY === 'Windows' ? '-n' : '-c';
         $this->currentCommand[] = (string) $this->count;
 
         return $this;


### PR DESCRIPTION
I encountered an issue while using this package on a Windows environment. Specifically, Windows does not support the -c flag for counting in the same way as Unix-based systems. Additionally, the original implementation required administrative privileges to execute correctly on Windows.
To address this, I proposed an update to the command add-on logic in the package. The update introduces a check for the operating system on which the package is running. Based on the detected OS, it dynamically applies the appropriate command syntax.