### PR TITLE
Recognise more iputils ping error strings

### DIFF
--- a/src/PingResult.php
+++ b/src/PingResult.php
@@ -219,7 +219,8 @@ class PingResult implements Stringable
             return PingError::HostnameNotFound;
         }
 
-        if (str_contains($output, 'no route to host') || str_contains($output, 'host unreachable')) {
+        if (str_contains($output, 'no route to host')
+            || preg_match('/(?:destination\\s+)?(?:net|port|host)\\s+unreachable/', $output) === 1) {
             return PingError::HostUnreachable;
         }
 
@@ -227,7 +228,9 @@ class PingResult implements Stringable
             return PingError::PermissionDenied;
         }
 
-        if (str_contains($output, 'timeout') || str_contains($output, 'timed out')) {
+        if (str_contains($output, 'timeout')
+            || str_contains($output, 'timed out')
+            || str_contains($output, 'no answer yet for icmp_seq')) {
             return PingError::Timeout;
         }
 

--- a/src/PingResult.php
+++ b/src/PingResult.php
@@ -215,23 +215,17 @@ class PingResult implements Stringable
     {
         $output = strtolower($output);
 
-        if (str_contains($output, 'unknown host') || str_contains($output, 'name or service not known')) {
-            return PingError::HostnameNotFound;
-        }
+        $errorsByNeedles = [
+            [PingError::HostnameNotFound, ['unknown host', 'name or service not known']],
+            [PingError::HostUnreachable, ['no route to host', 'net unreachable', 'port unreachable', 'host unreachable']],
+            [PingError::PermissionDenied, ['permission denied']],
+            [PingError::Timeout, ['timeout', 'timed out', 'no answer yet for icmp_seq']],
+        ];
 
-        if (str_contains($output, 'no route to host')
-            || preg_match('/(?:destination\s+)?(?:net|port|host)\s+unreachable/', $output) === 1) {
-            return PingError::HostUnreachable;
-        }
-
-        if (str_contains($output, 'permission denied')) {
-            return PingError::PermissionDenied;
-        }
-
-        if (str_contains($output, 'timeout')
-            || str_contains($output, 'timed out')
-            || str_contains($output, 'no answer yet for icmp_seq')) {
-            return PingError::Timeout;
+        foreach ($errorsByNeedles as [$error, $needles]) {
+            if (array_any($needles, fn (string $needle) => str_contains($output, $needle))) {
+                return $error;
+            }
         }
 
         return PingError::UnknownError;

--- a/src/PingResult.php
+++ b/src/PingResult.php
@@ -220,7 +220,7 @@ class PingResult implements Stringable
         }
 
         if (str_contains($output, 'no route to host')
-            || preg_match('/(?:destination\\s+)?(?:net|port|host)\\s+unreachable/', $output) === 1) {
+            || preg_match('/(?:destination\s+)?(?:net|port|host)\s+unreachable/', $output) === 1) {
             return PingError::HostUnreachable;
         }
 

--- a/tests/PingCheckerTest.php
+++ b/tests/PingCheckerTest.php
@@ -531,3 +531,28 @@ it('can create PingResult from toArray with ip_version', function () {
     expect($result->ipVersion())->toBe(\Spatie\Ping\Enums\IpVersion::IPv6);
     expect($result->toArray()['options']['ip_version'])->toBe('ipv6');
 });
+
+it('classifies ICMP destination unreachable variants as host unreachable', function (string $line) {
+    $result = PingResult::fromPingOutput([$line], 1, 'example.com', 1);
+
+    expect($result->error())->toBe(PingError::HostUnreachable);
+})->with([
+    'From 10.0.0.1 icmp_seq=1 Destination Net Unreachable',
+    'From 10.0.0.1 icmp_seq=1 Destination Host Unreachable',
+    'From 10.0.0.1 icmp_seq=1 Destination Port Unreachable',
+]);
+
+it('classifies "no answer yet" iputils output as timeout', function () {
+    $output = [
+        'PING 23.88.67.24 (23.88.67.24) 56(84) bytes of data.',
+        'no answer yet for icmp_seq=1',
+        'no answer yet for icmp_seq=2',
+        '',
+        '--- 23.88.67.24 ping statistics ---',
+        '5 packets transmitted, 0 received, 100% packet loss, time 4097ms',
+    ];
+
+    $result = PingResult::fromPingOutput($output, 1, '23.88.67.24', 5);
+
+    expect($result->error())->toBe(PingError::Timeout);
+});


### PR DESCRIPTION
Two small additions to `PingResult::determineErrorFromOutput()` so that real-world iputils output stops falling through to `UnknownError`:

1. **`no answer yet for icmp_seq=N` -> `Timeout`.** This line is emitted by iputils when the `-O` flag is set, which this package enables by default via `showLostPackets`. It indicates a sequence number that hasn't been answered by the next interval tick, semantically a timeout. Today an all-lost ping with `-O` exits non-zero with only "no answer yet" + "100% packet loss" in the output and gets classified as `UnknownError`.

2. **`Destination Net/Port/Host Unreachable` -> `HostUnreachable`.** iputils prints these when an intermediate router replies with an ICMP unreachable. The existing `host unreachable` substring check catches the "Destination Host" variant by accident, but misses "Destination Net" and "Destination Port". Folded the three into one regex so all variants are matched in a single pass.

Sources in iputils: `ping/ping_common.c` for the `no answer yet for icmp_seq=` print (gated on `opt_outstanding`, i.e. `-O`), `ping/ping.c` for the ICMP unreachable strings.

Tests added covering all three "Destination ... Unreachable" variants and a full "no answer yet" output block.